### PR TITLE
Fix r_runner signature to match python_runner

### DIFF
--- a/pdpp/languages/runners.py
+++ b/pdpp/languages/runners.py
@@ -17,8 +17,8 @@ def python_runner(script_name: str, task: BaseTask):
     )
 
 
-def r_runner(script_name, target_dir, src_dir):
-    run(["Rscript", script_name], check=True, cwd=join(target_dir, src_dir))
+def r_runner(script_name: str, task: BaseTask):
+    run(["Rscript", script_name], check=True, cwd=join(task.target_dir, task.SRC_DIR))
 
 
 # TODO: Fix the project runner and bring it in line with the other runners


### PR DESCRIPTION
The r_runner function had an outdated signature (script_name, target_dir, src_dir) that didn't match how it's called in standard_task.py, which passes (script_name, task). This caused a TypeError when running R tasks.

Updated to match python_runner's signature: (script_name: str, task: BaseTask)